### PR TITLE
[Refactor] View, 혹은 Play 화면에 진입 후 나올 때 뷰가 업데이트 되던 현상을 개선

### DIFF
--- a/GyroData/Sources/Presentation/MotionList/Coordinator/MotionListCoordinator.swift
+++ b/GyroData/Sources/Presentation/MotionList/Coordinator/MotionListCoordinator.swift
@@ -15,6 +15,8 @@ final class MotionListCoordinator: Coordinator {
     var type: CoordinatorType { .list }
     var finishDelegate: CoordinatorFinishDelegate?
     
+    private weak var listDelegate: MotionListViewControllerDelegate?
+    
     init(navigationConrtoller: UINavigationController) {
         self.navigationController = navigationConrtoller
     }
@@ -32,6 +34,7 @@ private extension MotionListCoordinator {
             viewModel: DefaultMotionListViewModel(),
             coordinator: self
         )
+        listDelegate = viewController
         return viewController
     }
     
@@ -81,6 +84,7 @@ extension MotionListCoordinator: MotionListCoordinatorInterface {
     
     func popViewController() {
         navigationController.popViewController(animated: true)
+        listDelegate?.update()
     }
     
 }

--- a/GyroData/Sources/Presentation/MotionList/ViewControllers/MotionListViewController.swift
+++ b/GyroData/Sources/Presentation/MotionList/ViewControllers/MotionListViewController.swift
@@ -28,11 +28,6 @@ class MotionListViewController: UIViewController {
         setUp()
         bind()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.viewWillAppear()
-    }
 
     init(viewModel: MotionListViewModel, coordinator: MotionListCoordinatorInterface) {
         self.viewModel = viewModel
@@ -148,5 +143,19 @@ extension MotionListViewController: UITableViewDataSourcePrefetching {
         }
         viewModel.prefetch()
     }
+    
+}
+
+extension MotionListViewController: MotionListViewControllerDelegate {
+    
+    func update() {
+        viewModel.updateMotions()
+    }
+    
+}
+
+protocol MotionListViewControllerDelegate: AnyObject {
+
+    func update()
     
 }

--- a/GyroData/Sources/Presentation/MotionList/ViewModels/MotionListViewModel.swift
+++ b/GyroData/Sources/Presentation/MotionList/ViewModels/MotionListViewModel.swift
@@ -11,7 +11,7 @@ protocol MotionListViewModelInput {
     
     func didDeleteAction(at index: Int)
     func prefetch()
-    func viewWillAppear()
+    func updateMotions()
     
 }
 
@@ -60,7 +60,7 @@ final class DefaultMotionListViewModel: MotionListViewModel {
         isLoading.value = false
     }
     
-    func viewWillAppear() {
+    func updateMotions() {
         motions.value = storage.fetch(page: 1)
         currentPage = 1
     }

--- a/GyroData/Sources/Presentation/MotionPlay/ViewControllers/MotionPlayViewController.swift
+++ b/GyroData/Sources/Presentation/MotionPlay/ViewControllers/MotionPlayViewController.swift
@@ -40,7 +40,7 @@ final class MotionPlayViewController: UIViewController {
     }
     
     private func bind() {
-        dateLabel.text = viewModel.date.formatted()
+        dateLabel.text = viewModel.date.formatted(for: .display)
         titleLabel.text = viewModel.viewType.toTitle()
         
         if viewModel.viewType == .play {


### PR DESCRIPTION
- 측정하기 화면에서 저장버튼을 통해 화면을 빠져나올 때만 업데이트 하도록 구현

단순히 모션 데이터를 조회하기 위해 화면을 진입하고 빠져나올 때, 
이전 화면이 유지되는 것이 아니라 업데이트 되어 화면이 바뀌는 부분을 개선함.